### PR TITLE
Fix to prevent duplication of the word Add-On

### DIFF
--- a/class-gfsimpleaddon.php
+++ b/class-gfsimpleaddon.php
@@ -10,7 +10,7 @@ class GFSimpleAddOn extends GFAddOn {
 	protected $_path = 'simpleaddon/simpleaddon.php';
 	protected $_full_path = __FILE__;
 	protected $_title = 'Gravity Forms Simple Add-On';
-	protected $_short_title = 'Simple Add-On';
+	protected $_short_title = 'Simple Demo';
 
 	private static $_instance = null;
 


### PR DESCRIPTION
Found a little snag, where the uninstallation label for this example addon duplicates the word **"Add-On"**

Before:

![screen shot 2018-10-19 at 11 38 44](https://user-images.githubusercontent.com/5500952/47210968-9ef0c580-d394-11e8-8c21-a051e01cf8e2.png)

After:

![screen shot 2018-10-19 at 11 42 25](https://user-images.githubusercontent.com/5500952/47210983-a7490080-d394-11e8-8186-ee519adeadb5.png)
